### PR TITLE
Improved non-Linux platform interoperatbility

### DIFF
--- a/Sources/JSONEncoder.swift
+++ b/Sources/JSONEncoder.swift
@@ -2045,4 +2045,9 @@ fileprivate extension EncodingError {
     }
 }
 
+#else
+
+import Foundation
+public typealias JSONEncoder = Foundation.JSONEncoder
+
 #endif


### PR DESCRIPTION
You no longer have to switch between `import Foundation` on Apple platforms and `import JSONEncoderLinux` on Linux. You can use `import JSONEncoderLinux` on both.

On `Linux` builds `JSONEncoder` will typealias to `JSONEncoderLinux.JSONEncoder`.
On others, `JSONEncoder` will typealias to `Foundation.JSONEncoder`.