### PR TITLE
Reverted Apple platform compatibility

### DIFF
--- a/Sources/JSONEncoder.swift
+++ b/Sources/JSONEncoder.swift
@@ -2045,9 +2045,4 @@ fileprivate extension EncodingError {
     }
 }
 
-#else
-
-import Foundation
-public typealias JSONEncoder = Foundation.JSONEncoder
-
 #endif


### PR DESCRIPTION
**Xcode 9 beta 1** throws linker errors when this solution is applies.
Though `swift` compiler on both macOS and Linux compiles ok.

Need to revert back to using
```swift
import Foundation
#if os(Linux)
    import JSONEncoderLinux
#endif
```